### PR TITLE
Wrap May spawn in unsafe block

### DIFF
--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -38,7 +38,7 @@ impl Scheduler {
             syscall_tx: self.syscall_tx.clone(),
         };
 
-        let handle: JoinHandle<()> = may::coroutine::spawn(move || f(ctx));
+        let handle: JoinHandle<()> = unsafe { may::coroutine::spawn(move || f(ctx)) };
 
         self.tasks.insert(tid, Task { tid, handle });
         tid


### PR DESCRIPTION
## Summary
- wrap `may::coroutine::spawn` with an unsafe block in `Scheduler::spawn`

## Testing
- `cargo test -p scheduler`

------
https://chatgpt.com/codex/tasks/task_e_68603a9f97e0832fb19322bdb99b2628