### PR TITLE
Add maintenance task file and update crates

### DIFF
--- a/tasks/cli/tasks.md
+++ b/tasks/cli/tasks.md
@@ -12,3 +12,4 @@ Ensure the `tctl` CLI can:
 - [ ] Implement basic `tctl status` command that queries `/status` endpoint
 - [ ] Add unit test that mocks an API response and verifies output formatting
 - [ ] Extend CLI help output with `--json`, `--plain` flags
+- [ ] Replace the placeholder tests in `cli/tests` with minimal integration tests for argument parsing

--- a/tasks/daemon/tasks.md
+++ b/tasks/daemon/tasks.md
@@ -18,3 +18,4 @@ Build the binary entrypoint for the `tinkerbell` agent, responsible for:
 - [ ] Add placeholder config loader (`config.rs`) using `serde` + `toml`
 - [ ] Plan file-watcher support for hot-reload of config (inotify / fsevents)
 - [ ] Add integration test to spawn the daemon and shut it down gracefully
+- [ ] Replace placeholder daemon tests with a check that init and run return successfully

--- a/tasks/maintenance/tasks.md
+++ b/tasks/maintenance/tasks.md
@@ -1,0 +1,11 @@
+# Workspace Maintenance Tasks
+
+## Goal
+General cleanup and repository hygiene to ensure smooth development.
+
+## Tasks
+
+- [ ] Format the workspace using `cargo fmt --all`.
+- [ ] Clean up duplicate or truncated commands in the `justfile`.
+- [ ] Remove the conversational closing line from `README.md`.
+- [ ] Replace placeholder tests with minimal meaningful tests across crates.

--- a/tasks/schedule/tasks.md
+++ b/tasks/schedule/tasks.md
@@ -44,6 +44,8 @@ Complete the MVP coroutine task scheduler by:
 - [ ] Remove any logic cloning or moving the `Task` struct (it contains `JoinHandle` and is not `Clone`)
 - [ ] Add integration test that spawns two tasks and tracks their `SystemCall::Done` order
 - [ ] Confirm that scheduler exits cleanly after all tasks complete
+- [ ] Wrap the call to `may::coroutine::spawn` in an explicit `unsafe` block in `Scheduler::spawn`
+- [ ] Replace any placeholder tests with meaningful coverage for the ready queue
 
 
 ## Crate Types


### PR DESCRIPTION
## Summary
- add maintenance task checklist
- note placeholder test improvements in cli, daemon, and scheduler
- document unsafe wrap requirement for scheduler

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_68603816aa00832fb68dc1fc7754c3b8