### PR TITLE
Improve scheduler ready queue

### DIFF
--- a/crates/scheduler/README.md
+++ b/crates/scheduler/README.md
@@ -27,10 +27,11 @@ The scheduler should:
 |-----------------|---------------------------------------------------------------|
 | `Task`          | A generator-style coroutine that can yield system calls       |
 | `Scheduler`     | Manages task queue, blocking map, and the main loop           |
-| `SystemCall`    | An abstract yield, e.g., `Sleep`, `Spawn`, `Join`, `Log`      |
+| `SystemCall`    | An abstract yield, e.g., `Sleep`, `Spawn`, `Join`, `Log` |
 | `ReadyQueue`    | FIFO queue of runnable tasks built on `VecDeque<TaskId>` |
-| `CallStack`     | LIFO per-task stack for nested coroutine trampolining         |
-| `WaitMap`       | Tracks join/wait conditions for resumption                    |
+| `CallStack`     | LIFO per-task stack for nested coroutine trampolining |
+| `WaitMap`       | Tracks join/wait conditions for resumption |
+| `ready_len()`   | Inspect number of tasks currently queued |
 
 ---
 

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -28,6 +28,16 @@ impl Scheduler {
         }
     }
 
+    /// Return the number of tasks currently in the ready queue.
+    pub fn ready_len(&self) -> usize {
+        self.ready.len()
+    }
+
+    /// Check if the ready queue is empty.
+    pub fn ready_is_empty(&self) -> bool {
+        self.ready.is_empty()
+    }
+
     /// Spawn a new coroutine task with a TaskContext.
     ///
     /// # Safety
@@ -56,7 +66,7 @@ impl Scheduler {
     /// Run the scheduler loop, processing system calls from tasks.
     pub fn run(&mut self) -> Vec<TaskId> {
         let mut done_order = Vec::new();
-        while !self.tasks.is_empty() {
+        while let Some(_tid) = self.ready.pop() {
             match self.syscall_rx.recv_timeout(Duration::from_secs(5)) {
                 Ok((tid, syscall)) => {
                     match syscall {

--- a/crates/scheduler/tests/done_order.rs
+++ b/crates/scheduler/tests/done_order.rs
@@ -13,6 +13,7 @@ fn test_done_order() {
             ctx.syscall(SystemCall::Done);
         });
     }
+    assert_eq!(sched.ready_len(), 1);
 
     unsafe {
         // task 2 finishes first
@@ -21,7 +22,9 @@ fn test_done_order() {
             ctx.syscall(SystemCall::Done);
         });
     }
+    assert_eq!(sched.ready_len(), 2);
 
     let order = sched.run();
     assert_eq!(order, vec![2, 1]);
+    assert_eq!(sched.ready_len(), 0);
 }

--- a/crates/scheduler/tests/ready_queue.rs
+++ b/crates/scheduler/tests/ready_queue.rs
@@ -1,0 +1,12 @@
+use scheduler::ReadyQueue;
+
+#[test]
+fn test_ready_queue_fifo() {
+    let mut q = ReadyQueue::new();
+    q.push(1);
+    q.push(2);
+    assert_eq!(q.len(), 2);
+    assert_eq!(q.pop(), Some(1));
+    assert_eq!(q.pop(), Some(2));
+    assert!(q.is_empty());
+}


### PR DESCRIPTION
## Summary
- drive tasks by popping ready queue IDs before each syscall
- expose `ready_len` and `ready_is_empty` helpers
- document new method in README
- test ready queue FIFO order
- assert ready queue status in done-order test

## Testing
- `cargo fmt --all -- --check`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_686051c033f8832f9bd5859be1d7db6a