### PR TITLE
Implement tctl status command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,8 +250,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "cli"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "api",
+ "clap",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
@@ -653,6 +760,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +1026,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "overload"
@@ -1362,6 +1481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,6 +1787,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,3 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0"
+clap = { version = "4.4", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tonic = { version = "0.10", features = ["transport"] }
+tower = "0.4"
+serde_json = "1.0"
+api = { path = "../api" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -55,7 +55,7 @@ graph LR
 | Agent Status  | `tctl status`, `tctl agents`             | ✅        |
 | Logging       | `tctl logs tail`, `logs grep`            | ⏳        |
 | Secrets Mgmt  | `tctl secret add`, `secret list`         | ⏳        |
-| Help/Docs     | `tctl --help`, `--json` output           | ✅        | 
+| Help/Docs     | `tctl --help`, `--json`, `--plain`       | ✅        |
 | Lifecycle     | `tctl pause`, `tctl shutdown or restart` | ✅      |
 | Memory Access | `tctl memory show`, `memory edit`        | ⏳        |
 | Debugging     | `tctl debug`, `debug trace`              | ⏳        |
@@ -87,6 +87,10 @@ export TCTL_ADDR=vsock://3:5000
 ```bash
 # Show agent status
 tctl status
+# JSON formatted
+tctl status --json
+# Plain text
+tctl status --plain
 
 # Submit a plan
 tctl task submit --file plan.json

--- a/crates/cli/bin/tctl.rs
+++ b/crates/cli/bin/tctl.rs
@@ -1,0 +1,23 @@
+use cli::{Cli, Commands};
+use cli::commands::status::{self, OutputFormat};
+use cli::transport;
+use clap::Parser;
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let cli = Cli::parse();
+    let fmt = if cli.json { OutputFormat::Json } else { OutputFormat::Plain };
+
+    match cli.command {
+        Commands::Status => {
+            let chan = transport::connect(&cli.endpoint).await?;
+            let mut client = api::pb::api_client::ApiClient::new(chan);
+            let reply = status::fetch_status(&mut client).await?;
+            let out = status::render(reply, if cli.plain { OutputFormat::Plain } else { fmt });
+            println!("{}", out);
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod status;

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use api::pb::api_client::ApiClient;
+use api::pb::{Empty, StatusReply};
+use tonic::transport::Channel;
+
+/// Query the agent for its current status message.
+#[tracing::instrument(level = "debug", skip(client))]
+pub async fn fetch_status(client: &mut ApiClient<Channel>) -> Result<StatusReply> {
+    let resp = client.status(tonic::Request::new(Empty {})).await?;
+    Ok(resp.into_inner())
+}
+
+/// Format type for CLI output.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum OutputFormat {
+    /// Human readable plain text.
+    Plain,
+    /// JSON formatted output.
+    Json,
+}
+
+/// Format the status reply according to the selected [`OutputFormat`].
+pub fn render(reply: StatusReply, fmt: OutputFormat) -> String {
+    match fmt {
+        OutputFormat::Plain => reply.message,
+        OutputFormat::Json => serde_json::json!({ "message": reply.message }).to_string(),
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,7 +1,30 @@
-mod commands;
-mod transport;
+//! CLI library exposing commands and transport utilities.
 
-#[allow(unused)]
-fn main() {
-    println!("cli starting...");
+pub mod commands;
+pub mod transport;
+
+use clap::{Parser, Subcommand};
+
+/// Global command line options and subcommands.
+#[derive(Parser, Debug)]
+#[command(name = "tctl")]
+pub struct Cli {
+    /// Output as JSON
+    #[arg(long, global = true)]
+    pub json: bool,
+    /// Output in plain text
+    #[arg(long, global = true)]
+    pub plain: bool,
+    /// Endpoint of the daemon
+    #[arg(long, default_value = "unix:/tmp/tinkerbell.sock", global = true)]
+    pub endpoint: String,
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// CLI subcommands.
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Show daemon status
+    Status,
 }

--- a/crates/cli/src/tests/status.rs
+++ b/crates/cli/src/tests/status.rs
@@ -1,0 +1,67 @@
+use crate::commands::status::{fetch_status, render, OutputFormat};
+use crate::transport;
+use api::pb::api_server::{Api, ApiServer};
+use api::pb::{Empty, StatusReply, Task, TaskAck};
+use tonic::{Request, Response, Status};
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+
+struct MockApi;
+
+#[tonic::async_trait]
+impl Api for MockApi {
+    async fn status(&self, _req: Request<Empty>) -> Result<Response<StatusReply>, Status> {
+        Ok(Response::new(StatusReply { message: "ok".into() }))
+    }
+
+    async fn task_submit(&self, _req: Request<Task>) -> Result<Response<TaskAck>, Status> {
+        unimplemented!()
+    }
+
+    async fn ping(&self, _req: Request<Empty>) -> Result<Response<Empty>, Status> {
+        Ok(Response::new(Empty {}))
+    }
+}
+
+#[tokio::test]
+async fn status_plain() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(ApiServer::new(MockApi))
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async { rx.await.ok(); })
+            .await
+            .unwrap();
+    });
+
+    let channel = transport::connect(&addr.to_string()).await.unwrap();
+    let mut client = api::pb::api_client::ApiClient::new(channel);
+    let reply = fetch_status(&mut client).await.unwrap();
+    assert_eq!(render(reply, OutputFormat::Plain), "ok");
+
+    let _ = tx.send(());
+}
+
+#[tokio::test]
+async fn status_json() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(ApiServer::new(MockApi))
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async { rx.await.ok(); })
+            .await
+            .unwrap();
+    });
+
+    let channel = transport::connect(&addr.to_string()).await.unwrap();
+    let mut client = api::pb::api_client::ApiClient::new(channel);
+    let reply = fetch_status(&mut client).await.unwrap();
+    assert_eq!(render(reply, OutputFormat::Json), "{\"message\":\"ok\"}");
+
+    let _ = tx.send(());
+}

--- a/crates/cli/src/transport.rs
+++ b/crates/cli/src/transport.rs
@@ -1,1 +1,23 @@
+use anyhow::Result;
+use tokio::net::UnixStream;
+use tonic::transport::{Channel, Endpoint};
+use tower::service_fn;
 
+/// Connect to the gRPC server using either a TCP or Unix socket.
+#[tracing::instrument]
+pub async fn connect(addr: &str) -> Result<Channel> {
+    if addr.starts_with("unix:") {
+        let path = addr
+            .trim_start_matches("unix:")
+            .trim_start_matches("//")
+            .to_string();
+        let ep = Endpoint::try_from("http://[::]:50051")?;
+        let channel = ep
+            .connect_with_connector(service_fn(move |_| UnixStream::connect(path.clone())))
+            .await?;
+        Ok(channel)
+    } else {
+        let ep = Endpoint::try_from(format!("http://{addr}"))?;
+        Ok(ep.connect().await?)
+    }
+}

--- a/crates/cli/tests/args.rs
+++ b/crates/cli/tests/args.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+use cli::{Cli, Commands};
+
+#[test]
+fn parse_status() {
+    let cli = Cli::parse_from(["tctl", "status"]);
+    assert!(matches!(cli.command, Commands::Status));
+}
+
+#[test]
+fn parse_json_flag() {
+    let cli = Cli::parse_from(["tctl", "--json", "status"]);
+    assert!(cli.json);
+}


### PR DESCRIPTION
## Summary
- add `status` command connecting to the API via gRPC
- implement transport abstraction supporting Unix and TCP
- wire up clap parsing in `tctl` binary with `--json` and `--plain`
- document new flags in CLI README
- add unit tests for command output and integration tests for argument parsing

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68605e61653c832fbc58913ecb73a43f