### PR TITLE
Maintenance cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,3 @@ We warmly welcome engineers, developers, architects, and enthusiasts passionate 
 
 * 📬 **[GitHub Discussions](https://github.com/microscaler/tinkerbell/discussions)**
 * 🚀 **[Open Issues](https://github.com/microscaler/tinkerbell/issues)**
-
----
-

--- a/crates/api/tests/compile.rs
+++ b/crates/api/tests/compile.rs
@@ -1,2 +1,8 @@
+use api::pb::StatusReply;
+
 #[test]
-fn compile() {}
+fn compile() {
+    let _reply = StatusReply {
+        message: String::new(),
+    };
+}

--- a/crates/canvas/src/lib.rs
+++ b/crates/canvas/src/lib.rs
@@ -1,1 +1,4 @@
-// canvas library module
+//! Canvas library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "canvas";

--- a/crates/canvas/tests/compile.rs
+++ b/crates/canvas/tests/compile.rs
@@ -1,4 +1,6 @@
-use canvas as _;
+use canvas::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("canvas", PLACEHOLDER);
+}

--- a/crates/cli/tests/compile.rs
+++ b/crates/cli/tests/compile.rs
@@ -1,4 +1,7 @@
-use cli as _;
+use clap::CommandFactory;
+use cli::Cli;
 
 #[test]
-fn compile() {}
+fn compile() {
+    let _cmd = Cli::command();
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,1 +1,4 @@
-// core library module
+//! Core library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "core";

--- a/crates/core/tests/compile.rs
+++ b/crates/core/tests/compile.rs
@@ -1,4 +1,6 @@
-use core as _;
+use core::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("core", PLACEHOLDER);
+}

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -1,1 +1,4 @@
-// executor library module
+//! Executor library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "executor";

--- a/crates/executor/tests/compile.rs
+++ b/crates/executor/tests/compile.rs
@@ -1,4 +1,6 @@
-use executor as _;
+use executor::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("executor", PLACEHOLDER);
+}

--- a/crates/graphdb/src/lib.rs
+++ b/crates/graphdb/src/lib.rs
@@ -1,1 +1,4 @@
-// graphdb library module
+//! Graph database library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "graphdb";

--- a/crates/graphdb/tests/compile.rs
+++ b/crates/graphdb/tests/compile.rs
@@ -1,4 +1,6 @@
-use graphdb as _;
+use graphdb::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("graphdb", PLACEHOLDER);
+}

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,1 +1,4 @@
-// logging library module
+//! Logging library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "logging";

--- a/crates/logging/tests/compile.rs
+++ b/crates/logging/tests/compile.rs
@@ -1,4 +1,6 @@
-use logging as _;
+use logging::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("logging", PLACEHOLDER);
+}

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,1 +1,4 @@
-// metrics library module
+//! Metrics library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "metrics";

--- a/crates/metrics/tests/compile.rs
+++ b/crates/metrics/tests/compile.rs
@@ -1,4 +1,6 @@
-use metrics as _;
+use metrics::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("metrics", PLACEHOLDER);
+}

--- a/crates/plugins/src/lib.rs
+++ b/crates/plugins/src/lib.rs
@@ -1,1 +1,4 @@
-// plugins library module
+//! Plugins library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "plugins";

--- a/crates/plugins/tests/compile.rs
+++ b/crates/plugins/tests/compile.rs
@@ -1,4 +1,6 @@
-use plugins as _;
+use plugins::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("plugins", PLACEHOLDER);
+}

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -1,1 +1,4 @@
-// router library module
+//! Router library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "router";

--- a/crates/router/tests/compile.rs
+++ b/crates/router/tests/compile.rs
@@ -1,4 +1,6 @@
-use router as _;
+use router::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("router", PLACEHOLDER);
+}

--- a/crates/scheduler/tests/compile.rs
+++ b/crates/scheduler/tests/compile.rs
@@ -1,4 +1,7 @@
-use scheduler as _;
+use scheduler::Scheduler;
 
 #[test]
-fn compile() {}
+fn compile() {
+    let s = Scheduler::new();
+    assert!(s.ready_is_empty());
+}

--- a/crates/wal/src/lib.rs
+++ b/crates/wal/src/lib.rs
@@ -1,1 +1,4 @@
-// wal library module
+//! Write-ahead log library module placeholder.
+
+/// Placeholder public constant used for compile tests.
+pub const PLACEHOLDER: &str = "wal";

--- a/crates/wal/tests/compile.rs
+++ b/crates/wal/tests/compile.rs
@@ -1,4 +1,6 @@
-use wal as _;
+use wal::PLACEHOLDER;
 
 #[test]
-fn compile() {}
+fn compile() {
+    assert_eq!("wal", PLACEHOLDER);
+}

--- a/justfile
+++ b/justfile
@@ -37,8 +37,6 @@ build-docsbook:
 default:
     @echo "Available commands: build, test, run-agent, run-cli"
 
-
-
 run-agent:
     cargo run -p daemon --bin tinkerbell
 


### PR DESCRIPTION
## Summary
- clean up trailing line in README
- tidy justfile whitespace
- add placeholder constants to crates with no API
- update compile tests to use simple APIs

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6860683ac50c832faa7c5f2efd2de90f