### PR TITLE
Assert tasks exist in scheduler ready queue

### DIFF
--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -100,7 +100,7 @@ impl Scheduler {
                 },
             };
 
-            let _ = self.tasks.get_mut(&tid);
+            let _task = self.tasks.get_mut(&tid).expect("task not found");
 
             match self.syscall_rx.recv_timeout(Duration::from_secs(5)) {
                 Ok((call_tid, syscall)) => {


### PR DESCRIPTION
## Summary
- assert that a popped ready task exists in `Scheduler`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test` *(fails: `test_done_order` panic)*

------
https://chatgpt.com/codex/tasks/task_e_6861ab330e1c832faafae3bada0eb691