### PR TITLE
Add scheduler start thread with barrier

### DIFF
--- a/crates/scheduler/tests/compile.rs
+++ b/crates/scheduler/tests/compile.rs
@@ -1,9 +1,16 @@
 use scheduler::Scheduler;
+use std::sync::{Arc, Barrier};
+use std::thread;
 
 #[test]
 fn compile() {
     let mut sched = Scheduler::new();
-    assert!(sched.ready_is_empty());
-    let order = sched.run();
+    let barrier = Arc::new(Barrier::new(2));
+    let order = thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
+        assert!(sched.ready_is_empty());
+        barrier.wait();
+        handle.join().unwrap()
+    });
     assert!(order.is_empty());
 }

--- a/crates/scheduler/tests/done_order.rs
+++ b/crates/scheduler/tests/done_order.rs
@@ -1,30 +1,37 @@
 use scheduler::task::TaskContext;
 use scheduler::{Scheduler, SystemCall};
+use std::sync::{Arc, Barrier};
+use std::thread;
 use std::time::Duration;
 
 #[test]
 fn test_done_order() {
     let mut sched = Scheduler::new();
+    let barrier = Arc::new(Barrier::new(2));
+    let order = thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
 
-    unsafe {
-        // task 1 sleeps longer so finishes second
-        sched.spawn(|ctx: TaskContext| {
-            std::thread::sleep(Duration::from_millis(50));
-            ctx.syscall(SystemCall::Done);
-        });
-    }
-    assert_eq!(sched.ready_len(), 1);
+        unsafe {
+            // task 1 sleeps longer so finishes second
+            sched.spawn(|ctx: TaskContext| {
+                std::thread::sleep(Duration::from_millis(50));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
+        assert_eq!(sched.ready_len(), 1);
 
-    unsafe {
-        // task 2 finishes first
-        sched.spawn(|ctx: TaskContext| {
-            std::thread::sleep(Duration::from_millis(10));
-            ctx.syscall(SystemCall::Done);
-        });
-    }
-    assert_eq!(sched.ready_len(), 2);
+        unsafe {
+            // task 2 finishes first
+            sched.spawn(|ctx: TaskContext| {
+                std::thread::sleep(Duration::from_millis(10));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
+        assert_eq!(sched.ready_len(), 2);
 
-    let order = sched.run();
+        barrier.wait();
+        handle.join().unwrap()
+    });
     assert_eq!(order, vec![2, 1]);
     assert_eq!(sched.ready_len(), 0);
 }

--- a/crates/scheduler/tests/integration.rs
+++ b/crates/scheduler/tests/integration.rs
@@ -1,27 +1,36 @@
 use scheduler::{Scheduler, SystemCall, task::TaskContext};
 use serial_test::serial;
+use std::sync::{Arc, Barrier};
+use std::thread;
 use std::time::Duration;
 
 #[test]
 #[serial]
 fn integration_task_order() {
     let mut sched = Scheduler::new();
+    let barrier = Arc::new(Barrier::new(2));
+    let order = thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
 
-    unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            std::thread::sleep(Duration::from_millis(50));
-            ctx.syscall(SystemCall::Done);
-        });
-    }
+        unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                std::thread::sleep(Duration::from_millis(50));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
 
-    unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            std::thread::sleep(Duration::from_millis(10));
-            ctx.syscall(SystemCall::Done);
-        });
-    }
+        unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                std::thread::sleep(Duration::from_millis(10));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
 
-    let order = sched.run();
+        barrier.wait();
+        let order = handle.join().unwrap();
+        assert_eq!(order, vec![2, 1]);
+        order
+    });
     assert_eq!(order, vec![2, 1]);
 }
 
@@ -29,34 +38,44 @@ fn integration_task_order() {
 #[serial]
 fn integration_join_and_io_wait() {
     let mut sched = Scheduler::new();
-    let io_tx = sched.io_handle();
+    let barrier = Arc::new(Barrier::new(2));
+    let (child, order) = thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
+        let io_tx = sched.io_handle();
 
-    let child = unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::Done);
-        })
-    };
+        let child = unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::Done);
+            })
+        };
 
-    unsafe {
-        sched.spawn(move |ctx: TaskContext| {
-            ctx.syscall(SystemCall::Join(child));
-            ctx.syscall(SystemCall::Done);
+        unsafe {
+            sched.spawn(move |ctx: TaskContext| {
+                ctx.syscall(SystemCall::Join(child));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
+
+        unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::IoWait(1));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
+
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            io_tx.send(1).unwrap();
         });
-    }
 
-    unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::IoWait(1));
-            ctx.syscall(SystemCall::Done);
-        });
-    }
-
-    std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_millis(20));
-        io_tx.send(1).unwrap();
+        barrier.wait();
+        let order = handle.join().unwrap();
+        assert_eq!(order.len(), 3);
+        assert!(order.contains(&child));
+        assert!(order.contains(&2));
+        assert!(order.contains(&3));
+        (child, order)
     });
-
-    let order = sched.run();
     assert_eq!(order.len(), 3);
     assert!(order.contains(&child));
     assert!(order.contains(&2));

--- a/crates/scheduler/tests/io_wait.rs
+++ b/crates/scheduler/tests/io_wait.rs
@@ -1,23 +1,32 @@
 use scheduler::{Scheduler, SystemCall, task::TaskContext};
+use std::sync::{Arc, Barrier};
+use std::thread;
 use std::time::Duration;
 
 #[test]
 fn test_io_wait_wakes_task() {
     let mut sched = Scheduler::new();
-    let io_tx = sched.io_handle();
+    let barrier = Arc::new(Barrier::new(2));
+    let order = thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
+        let io_tx = sched.io_handle();
 
-    unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::IoWait(1));
-            ctx.syscall(SystemCall::Done);
+        unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::IoWait(1));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
+
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            io_tx.send(1).unwrap();
         });
-    }
 
-    std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_millis(50));
-        io_tx.send(1).unwrap();
+        barrier.wait();
+        let order = handle.join().unwrap();
+        assert_eq!(order, vec![1]);
+        order
     });
-
-    let order = sched.run();
     assert_eq!(order, vec![1]);
 }

--- a/crates/scheduler/tests/join.rs
+++ b/crates/scheduler/tests/join.rs
@@ -1,24 +1,33 @@
 use scheduler::{Scheduler, SystemCall, task::TaskContext};
 use serial_test::serial;
+use std::sync::{Arc, Barrier};
+use std::thread;
 
 #[test]
 #[serial]
 fn test_join_wakes_waiter() {
     let mut sched = Scheduler::new();
+    let barrier = Arc::new(Barrier::new(2));
+    let (child, parent, order) = thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
 
-    let child = unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::Done);
-        })
-    };
+        let child = unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::Done);
+            })
+        };
 
-    let parent = unsafe {
-        sched.spawn(move |ctx: TaskContext| {
-            ctx.syscall(SystemCall::Join(child));
-            ctx.syscall(SystemCall::Done);
-        })
-    };
+        let parent = unsafe {
+            sched.spawn(move |ctx: TaskContext| {
+                ctx.syscall(SystemCall::Join(child));
+                ctx.syscall(SystemCall::Done);
+            })
+        };
 
-    let order = sched.run();
+        barrier.wait();
+        let order = handle.join().unwrap();
+        assert_eq!(order, vec![child, parent]);
+        (child, parent, order)
+    });
     assert_eq!(order, vec![child, parent]);
 }

--- a/crates/scheduler/tests/join_prompt.rs
+++ b/crates/scheduler/tests/join_prompt.rs
@@ -1,32 +1,41 @@
 use scheduler::{Scheduler, SystemCall, task::TaskContext};
+use std::sync::{Arc, Barrier};
+use std::thread;
 
 #[test]
 fn join_wake_before_next_ready() {
     let mut sched = Scheduler::new();
-    let child = unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::Done);
-        })
-    };
+    let barrier = Arc::new(Barrier::new(2));
+    let (child, parent, order) = thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
 
-    let parent = unsafe {
-        sched.spawn(move |ctx: TaskContext| {
-            ctx.syscall(SystemCall::Join(child));
-            ctx.syscall(SystemCall::Done);
-        })
-    };
+        let child = unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::Done);
+            })
+        };
 
-    let _third = unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::Done);
-        })
-    };
+        let parent = unsafe {
+            sched.spawn(move |ctx: TaskContext| {
+                ctx.syscall(SystemCall::Join(child));
+                ctx.syscall(SystemCall::Done);
+            })
+        };
 
-    let order = sched.run();
+        let _third = unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::Done);
+            })
+        };
+
+        barrier.wait();
+        let order = handle.join().unwrap();
+        (child, parent, order)
+    });
     let pos_child = order.iter().position(|&id| id == child).unwrap();
     let pos_parent = order.iter().position(|&id| id == parent).unwrap();
     assert!(
         pos_child < pos_parent,
-        "child should complete before parent"
+        "child should complete before parent",
     );
 }

--- a/crates/scheduler/tests/scheduler.rs
+++ b/crates/scheduler/tests/scheduler.rs
@@ -1,10 +1,15 @@
 #[test]
 fn test_may_scheduler() {
     let mut sched = scheduler::Scheduler::new();
-    unsafe {
-        sched.spawn(|_| {
-            println!("hello from may coroutine!");
-        });
-    }
-    let _ = sched.run();
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    std::thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
+        unsafe {
+            sched.spawn(|_| {
+                println!("hello from may coroutine!");
+            });
+        }
+        barrier.wait();
+        let _ = handle.join().unwrap();
+    });
 }

--- a/crates/scheduler/tests/sleep.rs
+++ b/crates/scheduler/tests/sleep.rs
@@ -1,27 +1,34 @@
 use scheduler::{Scheduler, syscall::SystemCall, task::TaskContext};
+use std::sync::{Arc, Barrier};
+use std::thread;
 use std::time::Duration;
 
 #[test]
 fn test_task_log_and_sleep_with_may() {
     let mut scheduler = Scheduler::new();
+    let barrier = Arc::new(Barrier::new(2));
+    thread::scope(|s| {
+        let handle = unsafe { scheduler.start(s, barrier.clone()) };
 
-    unsafe {
-        scheduler.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::Log("start task A".into()));
-            ctx.syscall(SystemCall::Sleep(Duration::from_millis(100)));
-            ctx.syscall(SystemCall::Log("resume task A".into()));
-            ctx.syscall(SystemCall::Done);
-        });
-    }
+        unsafe {
+            scheduler.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::Log("start task A".into()));
+                ctx.syscall(SystemCall::Sleep(Duration::from_millis(100)));
+                ctx.syscall(SystemCall::Log("resume task A".into()));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
 
-    unsafe {
-        scheduler.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::Log("start task B".into()));
-            ctx.syscall(SystemCall::Sleep(Duration::from_millis(100)));
-            ctx.syscall(SystemCall::Log("resume task B".into()));
-            ctx.syscall(SystemCall::Done);
-        });
-    }
+        unsafe {
+            scheduler.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::Log("start task B".into()));
+                ctx.syscall(SystemCall::Sleep(Duration::from_millis(100)));
+                ctx.syscall(SystemCall::Log("resume task B".into()));
+                ctx.syscall(SystemCall::Done);
+            });
+        }
 
-    let _ = scheduler.run();
+        barrier.wait();
+        let _ = handle.join().unwrap();
+    });
 }

--- a/crates/scheduler/tests/stale_ready.rs
+++ b/crates/scheduler/tests/stale_ready.rs
@@ -1,14 +1,21 @@
 use scheduler::{Scheduler, SystemCall, task::TaskContext};
+use std::sync::{Arc, Barrier};
+use std::thread;
 
 #[test]
 fn stale_ready_id_is_ignored() {
     let mut sched = Scheduler::new();
-    let child = unsafe {
-        sched.spawn(|ctx: TaskContext| {
-            ctx.syscall(SystemCall::Done);
-        })
-    };
-    sched.ready_push_duplicate_for_test(child);
-    let order = sched.run();
-    assert_eq!(order, vec![child]);
+    let barrier = Arc::new(Barrier::new(2));
+    thread::scope(|s| {
+        let handle = unsafe { sched.start(s, barrier.clone()) };
+        let child = unsafe {
+            sched.spawn(|ctx: TaskContext| {
+                ctx.syscall(SystemCall::Done);
+            })
+        };
+        sched.ready_push_duplicate_for_test(child);
+        barrier.wait();
+        let order = handle.join().unwrap();
+        assert_eq!(order, vec![child]);
+    });
 }


### PR DESCRIPTION
## Summary
- add `Scheduler::start` to run on a dedicated scoped thread and wait on a barrier
- use the barrier in tests so tasks start after the scheduler is ready
- update all scheduler tests accordingly

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p scheduler`


------
https://chatgpt.com/codex/tasks/task_e_68625b987888832f858291a07aaa20a3