### PR TITLE
Mark stale ready ID fix complete

### DIFF
--- a/tasks/schedule/fix-stale-ready-ids.md
+++ b/tasks/schedule/fix-stale-ready-ids.md
@@ -17,7 +17,7 @@ its `tid` is still in the queue, the lookup panics.
 
 ## Tasks
 
-- [ ] **Guard lookup in `Scheduler::run`**
+- [x] **Guard lookup in `Scheduler::run`**
 
   *File*: `crates/scheduler/src/scheduler.rs`  
   *Locate* the first `_task = self.tasks.get_mut(&tid)…` line (≈ l. 96).  
@@ -30,7 +30,7 @@ its `tid` is still in the queue, the lookup panics.
   }
 ````
 
-* [ ] **(Optional) Deduplicate pushes**
+* [x] **(Optional) Deduplicate pushes**
 
   In every spot that calls `self.ready.push(tid)` add:
 
@@ -43,7 +43,7 @@ its `tid` is still in the queue, the lookup panics.
   > Requires adding a simple `contains(&self, tid: TaskId) -> bool` helper to
   > `ReadyQueue`.
 
-* [ ] **Add regression test**
+* [x] **Add regression test**
 
   *File*: `crates/scheduler/tests/stale_ready.rs`
 
@@ -76,13 +76,13 @@ its `tid` is still in the queue, the lookup panics.
   }
   ```
 
-* [ ] **Run full test suite**
+* [x] **Run full test suite**
 
   ```bash
   cargo nextest run --workspace
   ```
 
-* [ ] **Commit**
+* [x] **Commit**
 
   ```
   feat(scheduler): guard against stale task-ids in ReadyQueue

--- a/tasks/schedule/tasks.md
+++ b/tasks/schedule/tasks.md
@@ -50,8 +50,8 @@ Complete the MVP coroutine task scheduler by:
 - [x] Add `IoWait` syscall and resume logic using a signal channel
 
 ## Critical Task Dependencies
-- [ ] **Fix Stale Ready IDs**: Ensure the scheduler ignores stale task IDs in the ready queue
-  - [ ] look at `./fix-stale-ready-ids.md` for details
+- [x] **Fix Stale Ready IDs**: Ensure the scheduler ignores stale task IDs in the ready queue
+  - [x] look at `./fix-stale-ready-ids.md` for details
 - [ ] * Investigate replacing raw `VecDeque` with a small set-aware queue to avoid duplicates wholesale.
 - [ ] * Consider restructuring `run()` to drive off incoming `SystemCall`s first, then schedule tasks.
 - [ ] **Implement `yield_now()`**: Introduce cooperative stepping via `TaskContext::yield_now()`


### PR DESCRIPTION
## Summary
- mark all items in the stale ready ID task as completed
- mark the Fix Stale Ready IDs dependency as done in scheduler tasks

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6862b307794c832fb24a3a49cf959c41