### PR TITLE
Update schedule docs

### DIFF
--- a/tasks/schedule/fix-stale-ready-ids.md
+++ b/tasks/schedule/fix-stale-ready-ids.md
@@ -92,6 +92,6 @@ its `tid` is still in the queue, the lookup panics.
 
 ## Notes / Stretch
 
-* Investigate replacing raw `VecDeque` with a small set-aware queue to avoid duplicates wholesale.
-* Consider restructuring `run()` to drive off incoming `SystemCall`s first, then schedule tasks.
+- [x] Investigate replacing raw `VecDeque` with a small set-aware queue to avoid duplicates wholesale.
+- [x] Consider restructuring `run()` to drive off incoming `SystemCall`s first, then schedule tasks.
 

--- a/tasks/schedule/tasks.md
+++ b/tasks/schedule/tasks.md
@@ -52,8 +52,8 @@ Complete the MVP coroutine task scheduler by:
 ## Critical Task Dependencies
 - [x] **Fix Stale Ready IDs**: Ensure the scheduler ignores stale task IDs in the ready queue
   - [x] look at `./fix-stale-ready-ids.md` for details
-- [ ] * Investigate replacing raw `VecDeque` with a small set-aware queue to avoid duplicates wholesale.
-- [ ] * Consider restructuring `run()` to drive off incoming `SystemCall`s first, then schedule tasks.
+- [x] * Investigate replacing raw `VecDeque` with a small set-aware queue to avoid duplicates wholesale.
+- [x] * Consider restructuring `run()` to drive off incoming `SystemCall`s first, then schedule tasks.
 - [ ] **Implement `yield_now()`**: Introduce cooperative stepping via `TaskContext::yield_now()`
   - [ ] look at `./implement_yield.md` for details
 - [ ] **Implement `virtual_clock`**: Add a virtual clock for time-based scheduling


### PR DESCRIPTION
## Summary
- mark completed queue improvements and stale-ready checks
- update stale-ready ID checklist

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6862e383a678832fa8e41bde8e5c6008