### PR TITLE
docs(schedule): mark yield, clock and io_poll complete

### DIFF
--- a/tasks/schedule/implement_yield.md
+++ b/tasks/schedule/implement_yield.md
@@ -20,13 +20,13 @@ We will mirror this by adding `TaskContext::yield_now()` and making
 
 ## Steps
 
-- [ ] **Extend `SystemCall`**
+- [x] **Extend `SystemCall`**
 
   ```rust
   SystemCall::Yield,
 ````
 
-* [ ] **Add helper on `TaskContext`**
+* [x] **Add helper on `TaskContext`**
 
   ```rust
   impl TaskContext {
@@ -36,17 +36,17 @@ We will mirror this by adding `TaskContext::yield_now()` and making
   }
   ```
 
-* [ ] **Handle `Yield` in `Scheduler::run`**
+* [x] **Handle `Yield` in `Scheduler::run`**
 
   ```rust
   SystemCall::Yield => { /* no-op except requeue */ }
   ```
 
-* [ ] **Re-queue immediately without sleep**
+* [x] **Re-queue immediately without sleep**
 
   Ensure `requeue = true` for `Yield`.
 
-* [ ] **Add regression test**
+* [x] **Add regression test**
 
   `crates/scheduler/tests/yield.rs`
 

--- a/tasks/schedule/io_poll.md
+++ b/tasks/schedule/io_poll.md
@@ -10,42 +10,42 @@ Real agent tasks will block on sockets/FIFOs. Replace manual `io_tx` with MIO
 (poll/epoll/kqueue) under `cfg(feature = "async-io")`.
 
 ## Acceptance
-* With  `--features async-io`, tests use `mio::Poll` for readiness.
-* Existing behaviour via in-memory channel retained when feature disabled.
+* [x] With  `--features async-io`, tests use `mio::Poll` for readiness.
+* [x] Existing behaviour via in-memory channel retained when feature disabled.
 
 ---
 
 ## Steps
 
-- [ ] **Add `mio` dependency (optional)**
+- [x] **Add `mio` dependency (optional)**
 
   ```toml
   mio = { version = "0.8", optional = true }
 
 
-* [ ] **`Scheduler` conditional field**
+* [x] **`Scheduler` conditional field**
 
   ```rust
   #[cfg(feature = "async-io")]
   poll: mio::Poll,
   ```
 
-* [ ] **Map `IoWait(io_id)` to registration**
+* [x] **Map `IoWait(io_id)` to registration**
 
   *Hint:* store `io_id -> Token` mapping, register FD, push to `wait_map`.
 
-* [ ] **Poll when ready queue empty**
+* [x] **Poll when ready queue empty**
 
   ```rust
   let events = poll.poll(&mut events, timeout)?;
   for ev in events { complete_io(ev.token().into()); }
   ```
 
-* [ ] **Feature flag guards**
+* [x] **Feature flag guards**
 
   Provide stub impl (current channel path) when feature is off.
 
-* [ ] **Add doc-test** demonstrating compile with:
+* [x] **Add doc-test** demonstrating compile with:
 
   ```bash
   cargo test -p scheduler --features async-io

--- a/tasks/schedule/tasks.md
+++ b/tasks/schedule/tasks.md
@@ -54,11 +54,11 @@ Complete the MVP coroutine task scheduler by:
   - [x] look at `./fix-stale-ready-ids.md` for details
 - [x] * Investigate replacing raw `VecDeque` with a small set-aware queue to avoid duplicates wholesale.
 - [x] * Consider restructuring `run()` to drive off incoming `SystemCall`s first, then schedule tasks.
-- [ ] **Implement `yield_now()`**: Introduce cooperative stepping via `TaskContext::yield_now()`
+- [x] **Implement `yield_now()`**: Introduce cooperative stepping via `TaskContext::yield_now()`
   - [ ] look at `./implement_yield.md` for details
-- [ ] **Implement `virtual_clock`**: Add a virtual clock for time-based scheduling
+- [x] **Implement `virtual_clock`**: Add a virtual clock for time-based scheduling
   - [ ] look at `./virtual_clock.md` for details
-- [ ] **Wire `IoWait` to Event Polling**: Use MIO for blocking I/O operations
+- [x] **Wire `IoWait` to Event Polling**: Use MIO for blocking I/O operations
   - [ ] look at `./io_poll.md` for details
 - [ ] **Implement `io_registry_trait` look at `./io_registry_trait.md`  for details
   - [ ] Run `cargo nextest` with and without `--features async-io` for full coverage.

--- a/tasks/schedule/virtual_clock.md
+++ b/tasks/schedule/virtual_clock.md
@@ -18,16 +18,16 @@ with virtual time via `TickClock` and a min-heap (`BinaryHeap`) of sleepers.
 
 ## Steps
 
-- [ ] **Add field to `Scheduler`**
+- [x] **Add field to `Scheduler`**
 
   ```rust
   clock: TickClock,
   sleepers: BinaryHeap<(Instant, TaskId)>, // min-heap on wake time
 
 
-* [ ] **Inject `TickClock::new(Instant::now())` in `new()`**
+* [x] **Inject `TickClock::new(Instant::now())` in `new()`**
 
-* [ ] **In `SystemCall::Sleep(dur)`**
+* [x] **In `SystemCall::Sleep(dur)`**
 
   ```rust
   let wake_at = self.clock.now() + dur;
@@ -35,7 +35,7 @@ with virtual time via `TickClock` and a min-heap (`BinaryHeap`) of sleepers.
   requeue = false;
   ```
 
-* [ ] **At top of each scheduler loop**
+* [x] **At top of each scheduler loop**
 
   ```rust
   while let Some(&(wake_at, tid)) = self.sleepers.peek() {
@@ -48,11 +48,11 @@ with virtual time via `TickClock` and a min-heap (`BinaryHeap`) of sleepers.
   }
   ```
 
-* [ ] **Advance clock when idle**
+* [x] **Advance clock when idle**
 
   If no ready tasks and no IO, tick clock by shortest `wake_at - now`.
 
-* [ ] **Add test**
+* [x] **Add test**
 
   `sleep_virtual.rs` ensures `Sleep(Duration::from_millis(50))` returns without
   wall-clock delay (check elapsed real time < 5 ms).


### PR DESCRIPTION
## Summary
- mark checklist items done for yield, clock and io poll

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6862f31a5254832f8cc7a4c926be98bd