### PR TITLE
docs: document scheduler internals

### DIFF
--- a/crates/scheduler/src/clock.rs
+++ b/crates/scheduler/src/clock.rs
@@ -2,20 +2,28 @@ use std::time::{Duration, Instant};
 
 #[allow(unused)]
 #[derive(Clone)]
+/// Virtual clock used by the scheduler for deterministic time control.
+///
+/// Rather than relying on the OS clock, the scheduler advances this clock
+/// when tasks sleep or when the system is idle. This makes tests run quickly
+/// and ensures time-based operations are reproducible.
 pub struct TickClock {
     now: Instant,
 }
 
 impl TickClock {
     #![allow(unused)]
+    /// Create a new clock starting at the given instant.
     pub fn new(start: Instant) -> Self {
         Self { now: start }
     }
 
+    /// Get the current time according to the virtual clock.
     pub fn now(&self) -> Instant {
         self.now
     }
 
+    /// Advance the clock by `dur`.
     pub fn tick(&mut self, dur: Duration) {
         self.now += dur;
     }

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -388,6 +388,7 @@ impl Scheduler {
         self.seq += 1;
     }
 
+    /// Insert `tid` into the ready queue respecting its priority.
     fn push_ready(&mut self, tid: TaskId) {
         if let Some(task) = self.tasks.get(&tid) {
             let entry = ReadyEntry {
@@ -400,6 +401,7 @@ impl Scheduler {
         }
     }
 
+    /// Return the earliest instant at which a sleeping task should be woken.
     fn next_wake_instant(&self) -> Option<Instant> {
         let sleep = self.sleepers.peek().map(|Reverse((when, _))| *when);
         let timeout = self
@@ -414,6 +416,7 @@ impl Scheduler {
         }
     }
 
+    /// Process a syscall emitted by `tid`, updating scheduler state and queueing follow-up work.
     fn handle_syscall(&mut self, tid: TaskId, syscall: SystemCall, done: &mut Vec<TaskId>) {
         let mut requeue = true;
         match syscall {


### PR DESCRIPTION
## Summary
- document `TickClock`
- explain scheduler helpers `push_ready`, `next_wake_instant` and `handle_syscall`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_68631946e5bc832f8ab0e807d335dea6